### PR TITLE
register IRoleStore instead of IRoleClaimStore

### DIFF
--- a/src/AspNetCore.Identity.DynamoDB/DynamoDBBuilder.cs
+++ b/src/AspNetCore.Identity.DynamoDB/DynamoDBBuilder.cs
@@ -43,7 +43,7 @@ namespace AspNetCore.Identity.DynamoDB
 
 		public DynamoDBIdentityBuilder<TUser, TRole> AddRoleStore<T>() where T : class
 		{
-			return AddSingleton(typeof(IRoleClaimStore<>).MakeGenericType(RoleType), typeof(T));
+			return AddSingleton(typeof(IRoleStore<>).MakeGenericType(RoleType), typeof(T));
 		}
 
 		public DynamoDBIdentityBuilder<TUser, TRole> AddRoleStore()


### PR DESCRIPTION
see https://github.com/aspnet/Identity/blob/dev/src/Microsoft.AspNetCore.Identity/RoleManager.cs
it expects a dependency injected IRoleStore.
also it downcasts to IRoleClaimStore at https://github.com/aspnet/Identity/blob/dev/src/Microsoft.AspNetCore.Identity/RoleManager.cs#L451