### PR TITLE
store claims values as encoded json list

### DIFF
--- a/src/AspNetCore.Identity.DynamoDB/AspNetCore.Identity.DynamoDB.csproj
+++ b/src/AspNetCore.Identity.DynamoDB/AspNetCore.Identity.DynamoDB.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.1" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/AspNetCore.Identity.DynamoDB/DynamoUserStore.cs
+++ b/src/AspNetCore.Identity.DynamoDB/DynamoUserStore.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -120,12 +120,21 @@ namespace AspNetCore.Identity.DynamoDB
 
 			var usersSearch = _context.ScanAsync<TUser>(new List<ScanCondition>
 			{
-				new ScanCondition("ClaimTypes", ScanOperator.Contains, claim.Type),
-				new ScanCondition("ClaimValues", ScanOperator.Contains, claim.Value)
+				new ScanCondition("ClaimTypes", ScanOperator.Contains, claim.Type)
 			});
-			var users = await usersSearch.GetRemainingAsync(cancellationToken);
 
-			return users?.Where(u => u.DeletedOn == default(DateTimeOffset)).ToList();
+			var users = await usersSearch.GetRemainingAsync(cancellationToken);
+			if (users == null)
+			{
+				users = new List<TUser>();
+			}
+
+			var results = from u in users
+						  where u.DeletedOn == default(DateTimeOffset)
+						  where u.HasClaim(claim)
+						  select u;
+
+			return results.ToList();
 		}
 
 		public Task SetEmailAsync(TUser user, string email, CancellationToken cancellationToken)


### PR DESCRIPTION
this is attempt at fixing #5 for user claims. roles could follow the same approach.

i've left claim type as is.
to allow multiple claims with the same type i've changed the way we use the claim values column.
instead of a bare string containing the claim value, it now contains a json encoded array of 1 or more claim values.
the user store's scan method has had to change to do in-memory filtering to cope.