### PR TITLE
Get all dynamoDB tables instead of just first 100.

### DIFF
--- a/src/AspNetCore.Identity.DynamoDB/DynamoRoleStore.cs
+++ b/src/AspNetCore.Identity.DynamoDB/DynamoRoleStore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -11,6 +11,7 @@ using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Util;
+using AspNetCore.Identity.DynamoDB.Extensions;
 using Microsoft.AspNetCore.Identity;
 
 namespace AspNetCore.Identity.DynamoDB
@@ -238,12 +239,7 @@ namespace AspNetCore.Identity.DynamoDB
 				}
 			};
 
-			var tablesResponse = await client.ListTablesAsync();
-			if (tablesResponse.HttpStatusCode != HttpStatusCode.OK)
-			{
-				throw new Exception("Couldn't get list of tables");
-			}
-			var tableNames = tablesResponse.TableNames;
+			var tableNames = await client.ListAllTablesAsync();
 
 			if (!tableNames.Contains(rolesTableName))
 			{

--- a/src/AspNetCore.Identity.DynamoDB/DynamoRoleUsersStore.cs
+++ b/src/AspNetCore.Identity.DynamoDB/DynamoRoleUsersStore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -10,6 +10,7 @@ using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Util;
+using AspNetCore.Identity.DynamoDB.Extensions;
 
 namespace AspNetCore.Identity.DynamoDB
 {
@@ -194,12 +195,7 @@ namespace AspNetCore.Identity.DynamoDB
 				}
 			};
 
-			var tablesResponse = await client.ListTablesAsync();
-			if (tablesResponse.HttpStatusCode != HttpStatusCode.OK)
-			{
-				throw new Exception("Couldn't get list of tables");
-			}
-			var tableNames = tablesResponse.TableNames;
+			var tableNames = await client.ListAllTablesAsync();
 
 			if (!tableNames.Contains(roleUsersTableName))
 			{

--- a/src/AspNetCore.Identity.DynamoDB/DynamoUserStore.cs
+++ b/src/AspNetCore.Identity.DynamoDB/DynamoUserStore.cs
@@ -818,13 +818,8 @@ namespace AspNetCore.Identity.DynamoDB
 					}
 				}
 			};
-
-			var tablesResponse = await client.ListTablesAsync();
-			if (tablesResponse.HttpStatusCode != HttpStatusCode.OK)
-			{
-				throw new Exception("Couldn't get list of tables");
-			}
-			var tableNames = tablesResponse.TableNames;
+			
+			var tableNames = await client.ListAllTablesAsync();
 
 			if (!tableNames.Contains(userTableName))
 			{

--- a/src/AspNetCore.Identity.DynamoDB/Extensions/DynamoDbClientExtensions.cs
+++ b/src/AspNetCore.Identity.DynamoDB/Extensions/DynamoDbClientExtensions.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+
+namespace AspNetCore.Identity.DynamoDB.Extensions
+{
+	public static class DynamoDbClientExtensions
+    {
+		public static async Task<List<string>> ListAllTablesAsync(this IAmazonDynamoDB client)
+		{
+			var tables = new List<string>();
+
+			var tableResponse = await ListTablesAsync(client, null);
+			tables.AddRange(tableResponse.TableNames);
+			while (tableResponse.LastEvaluatedTableName != null)
+			{
+				tableResponse = await ListTablesAsync(client, tableResponse.LastEvaluatedTableName);
+				tables.AddRange(tableResponse.TableNames);
+			}
+
+			return tables;
+		}
+
+		private static async Task<ListTablesResponse> ListTablesAsync(IAmazonDynamoDB client, string lastTableName)
+		{
+			var tablesResponse = await client.ListTablesAsync(lastTableName);
+			if (tablesResponse.HttpStatusCode != HttpStatusCode.OK)
+			{
+				throw new Exception("Couldn't get list of tables");
+			}
+
+			return tablesResponse;
+		}
+    }
+}


### PR DESCRIPTION
The PR is to go along with issue #8. This is a simple fix that allow more than 100 dynamoDB tables in your AWS account. 